### PR TITLE
Rename "IP address leak" to "IP address hidden"

### DIFF
--- a/live/caching.js
+++ b/live/caching.js
@@ -213,7 +213,7 @@ app.get('/toplevel.html', (req, res) => {
     <script src="https://test-pages.privacytests2.org/post_data.js"></script>
     <script>
       const results = {
-        "IP address leak": {
+        "IP address hidden": {
           "ipAddress": "${ip}",
           "description": "IP addresses can be used to uniquely identify a large percentage of users. A proxy, VPN, or Tor can mask a user's IP address."
         },

--- a/scripts/test.js
+++ b/scripts/test.js
@@ -215,10 +215,10 @@ const kHstsRoot = 'https://hsts.privacytests2.org';
 const ipAddressTest = async (results) => {
   const myIpAddress = await fetchIpAddress();
   log('ipAddressTest', { results });
-  const { description, ipAddress } = results['IP address leak'];
+  const { description, ipAddress } = results['IP address hidden'];
   log({ myIpAddress, deviceIpAddress: ipAddress });
   return {
-    'IP address leak': {
+    'IP address hidden': {
       description,
       passed: ipAddress !== myIpAddress
     }


### PR DESCRIPTION
All other test names are phrased positively, while this one is phrased negatively, which is confusing given the meaning of ✅ (hidden) and ❌ (leaked).

(P.S.: Cool project!)